### PR TITLE
Add labels to enable argocd visibility for the component in backstage

### DIFF
--- a/skeletons/manifests/manifests/argocd/app.yaml
+++ b/skeletons/manifests/manifests/argocd/app.yaml
@@ -2,6 +2,9 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: ${{ values.repoName | dump }}
+  labels:
+    app: ${{ values.workflowId }}
+    rht-gitops.com/janus-argocd: ${{ values.workflowId }}
 spec:
   destination:
     namespace: ${{ values.namespace }}


### PR DESCRIPTION
The janus-idp ArgoCD plugin relies on a label to exist, and matches it to the annotation defined for the component (define in component's catalog-info.yaml)

## What does this PR do / why we need it

## Which issue(s) does this PR fix

Fixes #?

## How to test changes / Special notes to the reviewer
